### PR TITLE
[BugFix] map colour plotting

### DIFF
--- a/src/components/res_map.js
+++ b/src/components/res_map.js
@@ -229,7 +229,7 @@ export default function ({data, regionHighlighted}) {
       currentMapData = data.states.reduce((acc, state) => {
         const beds = parseInt(state.total.beds);
         statistic.total += beds;
-        if (beds < statistic.maxConfirmed) {
+        if (beds > statistic.maxConfirmed) {
           statistic.maxConfirmed = beds;
         }
 
@@ -246,7 +246,7 @@ export default function ({data, regionHighlighted}) {
         currentMapData = stateObj.districts.reduce((acc, district) => {
           const beds = parseInt(stateObj.total.beds);
           statistic.total += beds;
-          if (beds < statistic.maxConfirmed) {
+          if (beds > statistic.maxConfirmed) {
             statistic.maxConfirmed = beds;
           }
           acc[district.name] = district.total.beds;


### PR DESCRIPTION
**Description of PR**
The colour plotting was not being for the map properly. Reason behind it was that `maxConfirmed` variable was not getting populated due to wrong condition.

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #...

**Checklist**

- [ ] Compiles and passes lint tests
- [ ] Properly formatted
- [x] Tested on desktop
- [ ] Tested on phone

**Screenshots**
